### PR TITLE
[ 訂閱會員功能 ] 會員權限功能追蹤 sperLike使用狀態

### DIFF
--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -6,6 +6,7 @@ const {
   timestamp,
   date,
   text,
+  boolean,
 } = require("drizzle-orm/pg-core");
 
 // 使用者(註冊登入)表格 和個人介面的資料分開
@@ -33,18 +34,25 @@ const activities = pgTable("activities", {
   location: varchar("location", { length: 255 }).notNull(),
   date: date("date").notNull(),
   description: text("description").notNull(),
-  created_by_id: integer("created_by_id").notNull().references(() => usersTable.id),
+  created_by_id: integer("created_by_id")
+    .notNull()
+    .references(() => usersTable.id),
   created_at: timestamp("created_at").defaultNow(),
-  image_url: varchar('image_url', { length: 255 }),
+  image_url: varchar("image_url", { length: 255 }),
 });
-//上傳照片
+// 上傳照片
+// 0615 擴充需要欄位改變
 const photosTable = pgTable("photos", {
   id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .references(() => usersTable.id)
+    .notNull(),
   image_url: varchar("image_url", { length: 255 }),
   image_key: varchar("image_key", { length: 255 }),
-  uploaded_at: timestamp("uploaded_at").defaultNow(),
+  uploadedAt: timestamp("uploaded_at").defaultNow(),
+  sequence: integer("sequence"),
+  is_avatar: boolean("is_avatar").default(false), // 讓使用者指定頭像
 });
-
 // 使用者個人檔案
 // 以 userId 當作唯一識別
 // const orientationEnum = pgEnum("orientation_enum", [
@@ -86,21 +94,24 @@ const productsTable = pgTable("products", {
 
 // 訂單表( 1筆 = 一次送禮行為 )
 
-const giftOrdersTable = pgTable("gift_orders",{
-    // 這邊的 id 是訂單流水編號（ 內部用 ）
-    id: serial().primaryKey().notNull(),
-    // 對外公告的訂單編號
-    order_id: varchar( "order_id" , { length: 40 }).notNull().unique(),
-    sender_id: integer().notNull().references(()=>usersTable.id),
-    receiver_id: integer().notNull().references(()=>usersTable.id),
-    status: varchar("status", { length: 20 }).default("pending"),
-    // LINE Pay transactionId
-    transaction_id: varchar("transaction_id", { length: 100 }),
-    // 訂單金額
-    amount: integer("amount").notNull(),
-    created_at: timestamp("created_at").defaultNow()
-})
-
+const giftOrdersTable = pgTable("gift_orders", {
+  // 這邊的 id 是訂單流水編號（ 內部用 ）
+  id: serial().primaryKey().notNull(),
+  // 對外公告的訂單編號
+  order_id: varchar("order_id", { length: 40 }).notNull().unique(),
+  sender_id: integer()
+    .notNull()
+    .references(() => usersTable.id),
+  receiver_id: integer()
+    .notNull()
+    .references(() => usersTable.id),
+  status: varchar("status", { length: 20 }).default("pending"),
+  // LINE Pay transactionId
+  transaction_id: varchar("transaction_id", { length: 100 }),
+  // 訂單金額
+  amount: integer("amount").notNull(),
+  created_at: timestamp("created_at").defaultNow(),
+});
 
 // 訂單明細( 1筆 = 一個商品 + 買的數量)
 const orderItemsTable = pgTable("order_items", {
@@ -126,20 +137,24 @@ const subscriptionPlansTable = pgTable("subscription_plans", {
 
 const subscriptionsTable = pgTable("subscriptions", {
   id: serial().primaryKey().notNull(),
-  user_id: integer().notNull(),
+  user_id: integer()
+    .notNull()
+    .references(() => usersTable.id),
   plan: varchar({ length: 20 }).notNull(),
   price: integer().notNull(),
   status: varchar({ length: 20 }).notNull(), // 狀態：pending, paid
   merchanttradeno: varchar({ length: 30 }).notNull(), // 綠界自訂編號（不能重複）
   trade_no: varchar({ length: 30 }), // 綠界平台回傳的交易編號
-  paid_at: timestamp(), 
+  paid_at: timestamp(),
   created_at: timestamp().defaultNow().notNull(),
+  start_date: timestamp("start_date", { withTimezone: true }).notNull(),
+  end_date: timestamp("end_date", { withTimezone: true }).notNull(),
 });
 
 const friendRequestsTable = pgTable("friend_requests", {
   id: serial("id").primaryKey(),
   from_id: integer("from_id").notNull(),
-  to_id: integer("to_id").notNull(), 
+  to_id: integer("to_id").notNull(),
   created_at: timestamp("created_at").defaultNow(),
 });
 
@@ -163,5 +178,5 @@ module.exports = {
   friendRequestsTable,
   subscriptionsTable,
   friendRequestsTable,
-  friendsTable
+  friendsTable,
 };

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -127,6 +127,18 @@ const orderItemsTable = pgTable("order_items", {
 
 // 喜歡不喜歡
 
+// 紀錄 Super Like的使用紀錄，限制使用次數 1次 | 付費 5次
+const superLikesTable = pgTable("super_likes", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => usersTable.id),
+  targetId: integer("target_id")
+    .notNull()
+    .references(() => usersTable.id),
+  usedAt: date("used_at", { mode: "date" }).notNull(),
+});
+
 // 訂閱(訂單)資料
 const subscriptionPlansTable = pgTable("subscription_plans", {
   id: serial().primaryKey().notNull(),
@@ -179,4 +191,5 @@ module.exports = {
   subscriptionsTable,
   friendRequestsTable,
   friendsTable,
+  superLikesTable,
 };

--- a/src/services/memberService.js
+++ b/src/services/memberService.js
@@ -1,0 +1,24 @@
+const { subscriptionsTable } = require("../db/schema");
+const { and, eq, lte, gte } = require("drizzle-orm");
+const db = require("../db/index");
+
+// 查詢當下使用者是否為會員
+const isValidMember = async (userId) => {
+  const present = new Date();
+  const memberRecord = await db
+    .select()
+    .from(subscriptionsTable)
+    .where(
+      and(
+        eq(subscriptionsTable.user_id, userId),
+        eq(subscriptionsTable.status, "paid"),
+        lte(subscriptionsTable.start_date, present), // 當前時間 <= 訂閱日時間 訂閱已生效
+        gte(subscriptionsTable.end_date, present) // 當前時間 >= 包含訂閱日結束時間 訂閱尚未過期
+      )
+    );
+  return memberRecord.length > 0;
+};
+
+module.exports = {
+  isValidMember,
+};

--- a/src/services/superLikeService.js
+++ b/src/services/superLikeService.js
@@ -1,0 +1,43 @@
+const db = require("../db/index.js");
+const { superLikesTable } = require("../db/schema.js");
+const { isValidMember } = require("./subscriptionService.js");
+const { eq, and } = require("drizzle-orm");
+
+// 使用者已經用了幾次 Super Like
+const getSuperLikeCounts = async (userId) => {
+  const today = new Date();
+
+  console.log("Today 的型別:", typeof today); // 檢查
+
+  const counts = await db
+    .select()
+    .from(superLikesTable)
+    .where(
+      and(eq(superLikesTable.userId, userId), eq(superLikesTable.usedAt, today))
+    );
+  // 使用者今天用幾次 Super like
+  return counts.length;
+};
+
+// （會員上限 5，非會員上限 1）判斷 Super Like 剩多少使用次數能用？ 是不是會員？
+const checkSuperLikeAuth = async (userId) => {
+  const isMember = await isValidMember(userId); // 顯示是否為會員
+  const usedCount = await getSuperLikeCounts(userId); // 知道今天已用幾次
+
+  // 用會員狀態決定使用上限、計算剩下幾次使用次數
+  const limit = isMember ? 5 : 1;
+  const remainingCount = limit - usedCount; // 還能用幾次;
+  const isWithinLimit = remainingCount > 0; // 是否還能送出super like
+
+  return {
+    isMember,
+    limit,
+    remainingCount,
+    isWithinLimit,
+  };
+};
+
+module.exports = {
+  getSuperLikeCounts,
+  checkSuperLikeAuth,
+};


### PR DESCRIPTION
#9 

為了避免PR過大包難以閱讀
所以後端這邊繼續拆成一部分一部分的推哦！

**Schema 調整：已重新合併進目前現有的 `subscriptionsTable` 表**
我想保留我原本判斷的方式，有增加類似 **會員有效權限日起始欄位**
用純日期直接判斷，比較方便取得我要的superlike按鈕功能次數使用狀態、滑滑人數上限狀態

<img width="562" alt="image" src="https://github.com/user-attachments/assets/06cabc3d-4b4d-40a6-a805-df8f9f85b977" />

<img width="677" alt="image" src="https://github.com/user-attachments/assets/a7302be6-efd6-4f20-a0ed-783b2ec16907" />


@sin-huang table後面還有先特此告知
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cb5e67bf-d3c0-4862-8ce9-7e71c1da14ba" />