### PR TITLE
[ 使用者加入/取消/顯示活動api]

### DIFF
--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -8,7 +8,7 @@ const {
   joinActivity,
   cancelJoinActivity,
 } = require("../services/activityService");
-
+// console.log("activities:", activities);
 const s3 = new S3Client({
   region: process.env.AWS_REGION,
   credentials: {
@@ -80,7 +80,7 @@ const getMyActivities = async (req, res) => {
       .orderBy(activities.id)
       .leftJoin(usersTable, eq(activities.created_by_id, usersTable.id))
       .where(eq(activities.created_by_id, userId));
-    console.log("資料庫查詢我的活動結果:", result);
+    // console.log("資料庫查詢我的活動結果:", result);
     res.json(result);
   } catch (err) {
     console.error("取得我的活動錯誤：", err);
@@ -217,6 +217,7 @@ const deleteActivity = async (req, res) => {
 const getMyJoinActivity = async (req, res) => {
   try {
     const userId = req.user.id;
+    console.log(userId)
     const activities = await getJoinedActivitiesByUserId(userId);
     res.json(activities);
   } catch (error) {

--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -7,7 +7,7 @@ const {
   getJoinedActivitiesByUserId,
   joinActivity,
   cancelJoinActivity,
-} = require('../services/activityService');
+} = require("../services/activityService");
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION,
@@ -49,7 +49,7 @@ const getAllActivities = async (req, res) => {
         image_url: activities.image_url,
         created_at: activities.created_at,
         created_by_id: activities.created_by_id,
-        created_by_username: usersTable.username, 
+        created_by_username: usersTable.username,
       })
       .from(activities)
       .orderBy(activities.id)
@@ -61,9 +61,9 @@ const getAllActivities = async (req, res) => {
   }
 };
 
-// 取得我創建的活動 
+// 取得我創建的活動
 const getMyActivities = async (req, res) => {
-  // const userId = req.user.id; // 由 token/middleware 取得  
+  const userId = req.user.id; // 由 token/middleware 取得
   try {
     const result = await db
       .select({
@@ -119,10 +119,9 @@ const getActivityById = async (req, res) => {
   }
 };
 
-
 const createActivity = async (req, res) => {
   const { title, location, date, description } = req.body;
-  // const created_by_id = req.user.id;
+  const created_by_id = req.user.id;
   let image_url = "";
 
   try {
@@ -131,7 +130,14 @@ const createActivity = async (req, res) => {
     }
     const [inserted] = await db
       .insert(activities)
-      .values({ title, location,  date: new Date(date), description, created_by_id, image_url })
+      .values({
+        title,
+        location,
+        date: new Date(date),
+        description,
+        created_by_id,
+        image_url,
+      })
       .returning();
     res.status(201).json(inserted);
   } catch (err) {
@@ -142,7 +148,7 @@ const createActivity = async (req, res) => {
 
 const updateActivity = async (req, res) => {
   const id = parseInt(req.params.id);
-  // const userId = req.user.id;
+  const userId = req.user.id;
 
   try {
     // 查原本的活動
@@ -188,7 +194,7 @@ const updateActivity = async (req, res) => {
 
 const deleteActivity = async (req, res) => {
   const id = parseInt(req.params.id);
-  // const userId = req.user.id;
+  const userId = req.user.id;
 
   try {
     const [activity] = await db
@@ -223,11 +229,17 @@ const postJoinActivity = async (req, res) => {
   try {
     const userId = req.user.id;
     const activityId = Number(req.params.id);
-    await joinActivity(userId, activityId);
-    res.json({ message: '已加入活動' });
+
+    const result = await joinActivity(userId, activityId);
+
+    if (!result.success) {
+      return res.status(409).json({ message: result.message });
+    }
+
+    return res.status(201).json({ message: result.message });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: '伺服器錯誤' });
+    res.status(500).json({ error: "伺服器錯誤" });
   }
 };
 
@@ -236,10 +248,10 @@ const deleteJoinActivity = async (req, res) => {
     const userId = req.user.id;
     const activityId = Number(req.params.id);
     await cancelJoinActivity(userId, activityId);
-    res.json({ message: '已取消活動' });
+    res.json({ message: "已取消活動" });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: '伺服器錯誤' });
+    res.status(500).json({ error: "伺服器錯誤" });
   }
 };
 

--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -3,6 +3,11 @@ const { activities, usersTable } = require("../db/schema.js");
 const { eq, and } = require("drizzle-orm");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const crypto = require("crypto");
+const {
+  getJoinedActivitiesByUserId,
+  joinActivity,
+  cancelJoinActivity,
+} = require('../services/activityService');
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION,
@@ -56,9 +61,9 @@ const getAllActivities = async (req, res) => {
   }
 };
 
-// 取得我的活動 
+// 取得我創建的活動 
 const getMyActivities = async (req, res) => {
-  const userId = req.user.id; // 由 token/middleware 取得  
+  // const userId = req.user.id; // 由 token/middleware 取得  
   try {
     const result = await db
       .select({
@@ -117,7 +122,7 @@ const getActivityById = async (req, res) => {
 
 const createActivity = async (req, res) => {
   const { title, location, date, description } = req.body;
-  const created_by_id = req.user.id;
+  // const created_by_id = req.user.id;
   let image_url = "";
 
   try {
@@ -137,7 +142,7 @@ const createActivity = async (req, res) => {
 
 const updateActivity = async (req, res) => {
   const id = parseInt(req.params.id);
-  const userId = req.user.id;
+  // const userId = req.user.id;
 
   try {
     // 查原本的活動
@@ -183,7 +188,7 @@ const updateActivity = async (req, res) => {
 
 const deleteActivity = async (req, res) => {
   const id = parseInt(req.params.id);
-  const userId = req.user.id;
+  // const userId = req.user.id;
 
   try {
     const [activity] = await db
@@ -202,6 +207,42 @@ const deleteActivity = async (req, res) => {
   }
 };
 
+//取得我想參加的活動(顯示)
+const getMyJoinActivity = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const activities = await getJoinedActivitiesByUserId(userId);
+    res.json(activities);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "伺服器錯誤" });
+  }
+};
+
+const postJoinActivity = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const activityId = Number(req.params.id);
+    await joinActivity(userId, activityId);
+    res.json({ message: '已加入活動' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: '伺服器錯誤' });
+  }
+};
+
+const deleteJoinActivity = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const activityId = Number(req.params.id);
+    await cancelJoinActivity(userId, activityId);
+    res.json({ message: '已取消活動' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: '伺服器錯誤' });
+  }
+};
+
 module.exports = {
   getAllActivities,
   getMyActivities,
@@ -209,4 +250,7 @@ module.exports = {
   createActivity,
   updateActivity,
   deleteActivity,
+  postJoinActivity,
+  deleteJoinActivity,
+  getMyJoinActivity,
 };

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -236,6 +236,7 @@ const userPreferencesTable = pgTable("user_preferences", {
   ageMin: integer("age_min").notNull(),
   ageMax: integer("age_max").notNull(),
 });
+
 const aiMemoriesTable = pgTable("ai_memories",{
   id: serial("id").primaryKey(),
   userId: integer("user_id").notNull().references(() => usersTable.id),
@@ -243,6 +244,19 @@ const aiMemoriesTable = pgTable("ai_memories",{
   content: text("content").notNull(),
   created_at: timestamp("created_at").defaultNow(),
 })
+
+const userAttendActivityTable = pgTable("user_attend_activity", {
+  userId: integer("user_id")
+    .notNull()
+    .references(() => usersTable.id),
+  activityId: integer("activity_id")
+    .notNull()
+    .references(() => activities.id),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.userId, table.activityId] }),
+  };
+});
 
 module.exports = {
   usersTable,
@@ -265,4 +279,5 @@ module.exports = {
   userInterestsTable,
   userPreferencesTable,
   aiMemoriesTable,
+  userAttendActivityTable
 };

--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -10,6 +10,9 @@ const {
   createActivity,
   updateActivity,
   deleteActivity,
+  getMyJoinActivity,
+  postJoinActivity,
+  deleteJoinActivity,
 } = require("../controllers/activityControllers.js");
 
 const authMiddleware = require("../middleware/auth.js");
@@ -17,11 +20,15 @@ const authMiddleware = require("../middleware/auth.js");
 // 公開取得所有活動
 router.get("/", getAllActivities);
 
-// 需要授權的操作
+// 需要授權的操作 使用者創建/編輯/刪除活動
 router.get("/my", authMiddleware, getMyActivities);
-router.get('/:id', authMiddleware, getActivityById);
+router.get("/me", authMiddleware, getMyJoinActivity);
+router.get("/:id", authMiddleware, getActivityById);
 router.post("/", authMiddleware, upload.single("image"), createActivity);
 router.put("/:id", authMiddleware, upload.single("image"), updateActivity);
 router.delete("/:id", authMiddleware, deleteActivity);
 
+//使用者(操作)加入/取消參與活動(資源)
+router.post("/join/:id", authMiddleware, postJoinActivity);
+router.delete("/join/:id", authMiddleware, deleteJoinActivity);
 module.exports = router;

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -1,6 +1,10 @@
 const db = require("../db/index.js");
 const { eq, and } = require("drizzle-orm");
-const { activities, userAttendActivityTable } = require("../db/schema.js");
+const {
+  activities,
+  userAttendActivityTable,
+  usersTable,
+} = require("../db/schema.js");
 
 const getActivityById = async (activityId) => {
   return await db
@@ -11,11 +15,14 @@ const getActivityById = async (activityId) => {
 };
 
 const getJoinedActivitiesByUserId = async (userId) => {
-  return await db
+  const res = await db
     .select({
-      activityId: activities.id,
+      id: activities.id,
       title: activities.title,
+      location: activities.location,
+      date: activities.date,
       description: activities.description,
+      image_url: activities.image_url,
     })
     .from(userAttendActivityTable)
     .innerJoin(
@@ -23,6 +30,8 @@ const getJoinedActivitiesByUserId = async (userId) => {
       eq(userAttendActivityTable.activityId, activities.id)
     )
     .where(eq(userAttendActivityTable.userId, userId));
+    console.log(res)
+    return res;
 };
 
 const joinActivity = async (userId, activityId) => {

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -1,0 +1,51 @@
+const db = require("../db/index.js");
+const { eq, and } = require("drizzle-orm");
+const {
+  activities,
+  userAttendActivityTable,
+} = require("../db/schema.js");
+
+const getActivityById = async (activityId) => {
+  return await db
+    .select()
+    .from(activities)
+    .where(eq(activities.id, activityId))
+    .limit(1); // 限制只返回一筆資料
+};
+
+const getJoinedActivitiesByUserId = async (userId) => {
+  return await db
+    .select({
+      activityId: activities.id,
+      title: activities.title,
+      description: activities.description,
+    })
+    .from(userAttendActivityTable)
+    .innerJoin(activities, eq(userAttendActivityTable.activityId, activities.id))
+    .where(eq(userAttendActivityTable.userId, userId));
+};
+
+const joinActivity = async (userId, activityId) => {
+  return await db.insert(userAttendActivityTable).values({
+    userId: userId, 
+    activityId: activityId, 
+  });
+};
+
+const cancelJoinActivity = async (userId, activityId) => {
+  return await db
+    .delete(userAttendActivityTable)
+    .where(
+      and(
+        eq(userAttendActivityTable.userId, userId),
+        eq(userAttendActivityTable.activityId, activityId)
+      )
+    );
+};
+
+module.exports = {
+  getActivityById,
+  joinActivity,
+  cancelJoinActivity,
+  getJoinedActivitiesByUserId
+};

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -1,9 +1,6 @@
 const db = require("../db/index.js");
 const { eq, and } = require("drizzle-orm");
-const {
-  activities,
-  userAttendActivityTable,
-} = require("../db/schema.js");
+const { activities, userAttendActivityTable } = require("../db/schema.js");
 
 const getActivityById = async (activityId) => {
   return await db
@@ -21,15 +18,35 @@ const getJoinedActivitiesByUserId = async (userId) => {
       description: activities.description,
     })
     .from(userAttendActivityTable)
-    .innerJoin(activities, eq(userAttendActivityTable.activityId, activities.id))
+    .innerJoin(
+      activities,
+      eq(userAttendActivityTable.activityId, activities.id)
+    )
     .where(eq(userAttendActivityTable.userId, userId));
 };
 
 const joinActivity = async (userId, activityId) => {
-  return await db.insert(userAttendActivityTable).values({
-    userId: userId, 
-    activityId: activityId, 
+  const existing = await db
+    .select()
+    .from(userAttendActivityTable)
+    .where(
+      and(
+        eq(userAttendActivityTable.userId, userId),
+        eq(userAttendActivityTable.activityId, activityId)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return { success: false, message: "使用者已經加入過此活動" };
+  }
+
+  await db.insert(userAttendActivityTable).values({
+    userId,
+    activityId,
   });
+
+  return { success: true, message: "成功加入活動" };
 };
 
 const cancelJoinActivity = async (userId, activityId) => {
@@ -47,5 +64,5 @@ module.exports = {
   getActivityById,
   joinActivity,
   cancelJoinActivity,
-  getJoinedActivitiesByUserId
+  getJoinedActivitiesByUserId,
 };


### PR DESCRIPTION
## 目的
實作使用者參加活動的相關功能，包含以下三個 API：

- 使用者報名活動（POST /activities/join/:id）
- 取消報名活動（DELETE /activities/join/:id）
- 取得使用者已報名活動清單（GET /activities/me）

## 主要變更
- 新增 `joinActivity`, `cancelJoinActivity`, `getJoinedActivitiesByUserId` service 函數
- 新增三個 controller：
  - `postJoinActivity`
  - `deleteJoinActivity`
  - `getMyJoinActivity`
- 檢查使用者是否已報名，避免重複加入活動

## 資料庫操作說明
- 使用 `userAttendActivityTable` 中介資料表進行 join/cancel 查詢與刪除

## 回傳格式說明
- 報名成功：`201 Created`，回傳 `{ message: "成功加入活動" }`
- 已報名：`409 Conflict`，回傳 `{ message: "使用者已經加入過此活動" }`
- 取消報名成功：`200 OK`，回傳 `{ message: "已取消活動" }`
- 錯誤：`500 Internal Server Error`，回傳 `{ error: "伺服器錯誤" }`