### PR TITLE
[ Bugfix 上傳大頭照 ] 上傳大頭照失敗、sequence改穩一點 

### DIFF
--- a/src/controllers/editPhotosControllers.js
+++ b/src/controllers/editPhotosControllers.js
@@ -4,7 +4,7 @@ const { DeleteObjectCommand } = require("@aws-sdk/client-s3");
 const { s3 } = require("../db/s3");
 const db = require("../db");
 const { photosTable } = require("../db/schema");
-const { eq, and, sql } = require("drizzle-orm");
+const { eq, and } = require("drizzle-orm");
 const { findSpecifiedPhotos, setAvatar } = require("../services/userPhoto.js");
 
 const getMyAvatarPhoto = async (req, res) => {
@@ -44,10 +44,14 @@ const uploadImage = async (req, res) => {
 
     const imageUrl = `https://${process.env.S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${fileKey}`;
 
-    const sequence = Number(req.body.sequence);
+    let sequence = null;
 
-    if (!sequence || sequence < 1) {
-      return res.status(400).json({ message: "缺少或無效的 sequence 編號" });
+    // 真的有傳值 的情況下才驗證
+    if ("sequence" in req.body) {
+      sequence = Number(req.body.sequence);
+      if (!Number.isInteger(sequence) || sequence < 1) {
+        return res.status(400).json({ message: "sequence 無效" });
+      }
     }
 
     const [newPhoto] = await db
@@ -56,7 +60,7 @@ const uploadImage = async (req, res) => {
         image_url: imageUrl,
         image_key: fileKey,
         userId,
-        sequence,
+        sequence, // 有給就儲存，沒給就 null
         is_avatar: false, // 每張上傳的照片一律都不是大頭貼
       })
       .returning();
@@ -104,7 +108,7 @@ const deletePhoto = async (req, res) => {
       return res.status(403).json({ message: "你無權刪除此圖片" });
     }
 
-    // 1. 刪 S3
+    // 刪 S3
     await s3.send(
       new DeleteObjectCommand({
         Bucket: process.env.S3_BUCKET_NAME,
@@ -112,7 +116,7 @@ const deletePhoto = async (req, res) => {
       })
     );
 
-    // 2. 刪資料庫
+    // 刪資料庫
     await db.delete(photosTable).where(eq(photosTable.image_key, key));
 
     res.json({ message: `已刪除：${key}` });
@@ -132,9 +136,9 @@ const changeAvatar = async (req, res) => {
   }
 
   try {
-    await setAvatar(userId, key); // 執行設定大頭貼
+    const result = await setAvatar(userId, key); // 執行設定大頭貼
 
-    res.json({ message: "大頭貼已更新", setAvatar });
+    res.json({ message: "大頭貼已更新", result });
   } catch (err) {
     console.error("更新大頭貼失敗", err);
     res.status(500).json({ message: "伺服器錯誤", error: err.message });

--- a/src/controllers/userPhotosControllers.js
+++ b/src/controllers/userPhotosControllers.js
@@ -22,7 +22,8 @@ const getMatchPhotos = async (req, res) => {
 
   try {
     const photos = await findSpecifiedPhotos(userId, { sequenceIn: [1, 2, 3] });
-    const randomPhotos = allPhotos.sort(() => 0.5 - Math.random());
+    // 只抓指定的三張照片，但每次打亂配對池的顯示照片順序
+    const randomPhotos = photos.sort(() => 0.5 - Math.random());
 
     // 取前3張（如果不足3張，就取有的）
     const selected = randomPhotos.slice(0, 3);


### PR DESCRIPTION
Finished #66 
先前的修改方式會導致avatar被判定成 sequence: null  被阻擋上傳
但同時又不希望單獨由後端決定sequence，導致的問題就是因為實際上傳的時間不同步 得到的 sequence值會大亂

現在由前端明確決定每張照片的 sequence 值
所以後端，不需猜測、不需排序
無論使用者上傳幾張、順序如何、是否同時操作，都不會亂掉
後端只處理資料存儲，不主動賦值  ⇨ `sequence: Number(req.body.sequence) // 前端傳多少就存多少`


前端使用生活照的方法：`uploadPhoto(file, sequence)`
- 因為一定會傳 sequence（由 uploadAll() 裡的 index + 1 控制）
- 且用於生活照，自動編排 1～6
- 所以沒有被拿來上傳大頭貼 → 不會有混用管理問題

⇨大頭照不會被誤設順序

<img width="769" alt="Image" src="https://github.com/user-attachments/assets/e61f4abe-18b3-4fd7-8bfe-773fd57dfc64" />

<img width="986" alt="Image" src="https://github.com/user-attachments/assets/cb63cac5-67a7-4dd4-a917-61939ff2f738" />