### PR TITLE
[ 修正活動建立時未設定 created_at 導致為 null 的問題

### DIFF
--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -159,6 +159,7 @@ const createActivity = async (req, res) => {
         description,
         created_by_id,
         image_url,
+        created_at: new Date(),
       })
       .returning();
     res.status(201).json({


### PR DESCRIPTION
## 調整內容說明
本次 PR 修正新增活動時未寫入 `created_at` 欄位的問題，導致資料庫中該欄位為 `null`。

## 修改項目
- 在 `createActivity` 的 API 中補上 `created_at: new Date()`。