### PR TITLE
[ 新增活動人數限制 ]

### DIFF
--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -147,7 +147,7 @@ const getActivityById = async (req, res) => {
 };
 
 const createActivity = async (req, res) => {
-  const { title, location, date, description } = req.body;
+  const { title, location, date, description,maxParticipants } = req.body;
   const created_by_id = req.user.id;
   let image_url = "";
 
@@ -165,6 +165,7 @@ const createActivity = async (req, res) => {
         created_by_id,
         image_url,
         created_at: new Date(),
+        max_participants:maxParticipants
       })
       .returning();
     res.status(201).json({
@@ -272,11 +273,10 @@ const postJoinActivity = async (req, res) => {
     const result = await joinActivity(userId, activityId);
 
     if (!result.success) {
-
       return res.status(409).json({ message: result.message });
     }
 
-    return res.status(201).json({ message: result.message });
+    return res.status(201).json({ message: result.message,current_participants: result.current_participants });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "伺服器錯誤" });

--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -168,6 +168,12 @@ const createActivity = async (req, res) => {
         max_participants:maxParticipants
       })
       .returning();
+
+    await db.insert(userAttendActivityTable).values({
+    userId: created_by_id,
+    activityId: inserted.id
+    });
+    
     res.status(201).json({
       ...inserted,
       date: formatDate(inserted.date),

--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -1,6 +1,6 @@
 const db = require("../db/index.js");
-const { activities, usersTable } = require("../db/schema.js");
-const { eq, and } = require("drizzle-orm");
+const { activities, usersTable,userAttendActivityTable } = require("../db/schema.js");
+const { eq, and, sql } = require("drizzle-orm");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const crypto = require("crypto");
 const {
@@ -59,10 +59,15 @@ const getAllActivities = async (req, res) => {
         created_at: activities.created_at,
         created_by_id: activities.created_by_id,
         created_by_username: usersTable.username,
+        max_participants:activities.max_participants,
+        current_participants: sql`COUNT(${userAttendActivityTable.userId})`.as("current_participants")
       })
       .from(activities)
-      .orderBy(activities.id)
-      .leftJoin(usersTable, eq(activities.created_by_id, usersTable.id));
+      .leftJoin(usersTable, eq(activities.created_by_id, usersTable.id))
+      .leftJoin(userAttendActivityTable, eq(activities.id, userAttendActivityTable.activityId))
+      .groupBy(activities.id,usersTable.username)
+      .orderBy(activities.id);
+
     const formatted = result.map((item) => ({
       ...item,
       date: formatDate(item.date),
@@ -267,6 +272,7 @@ const postJoinActivity = async (req, res) => {
     const result = await joinActivity(userId, activityId);
 
     if (!result.success) {
+
       return res.status(409).json({ message: result.message });
     }
 

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -31,7 +31,9 @@ const activities = pgTable("activities", {
     .references(() => usersTable.id),
   created_at: timestamp("created_at").defaultNow(),
   image_url: varchar("image_url", { length: 255 }),
+  max_participants: integer("max_participants").default(0),
 });
+
 //上傳照片
 const photosTable = pgTable("photos", {
   id: serial("id").primaryKey(),

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -1,5 +1,5 @@
 const db = require("../db/index.js");
-const { eq, and } = require("drizzle-orm");
+const { eq, and, sql } = require("drizzle-orm");
 const {
   activities,
   userAttendActivityTable,
@@ -48,6 +48,32 @@ const joinActivity = async (userId, activityId) => {
 
   if (existing.length > 0) {
     return { success: false, message: "使用者已經加入過此活動" };
+  }
+
+  // 2. 查詢該活動最多可容納多少人
+  const activity = await db
+    .select({ max: activities.max_participants })
+    .from(activities)
+    .where(eq(activities.id, activityId))
+    .limit(1);
+
+  if (activity.length === 0) {
+    return { success: false, message: "找不到該活動" };
+  }
+
+  const maxParticipants = activity[0].max;
+  // console.log(maxParticipants)
+  // 查詢目前已報名人數
+  const countResult = await db
+    .select({ count: sql`COUNT(${userAttendActivityTable.activityId})` })
+    .from(userAttendActivityTable)
+    .where(eq(userAttendActivityTable.activityId, activityId));
+
+  const currentCount = countResult[0]?.count || 0;
+  // console.log(currentCount)
+
+  if (currentCount >= maxParticipants) {
+    return { success: false, message: "人數已滿，無法再報名" };
   }
 
   await db.insert(userAttendActivityTable).values({

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -47,7 +47,7 @@ const joinActivity = async (userId, activityId) => {
     .limit(1);
 
   if (existing.length > 0) {
-    return { success: false, message: "使用者已經加入過此活動" };
+    return { success: false, message: "你已經加入過此活動" };
   }
 
   // 2. 查詢該活動最多可容納多少人
@@ -69,8 +69,7 @@ const joinActivity = async (userId, activityId) => {
     .from(userAttendActivityTable)
     .where(eq(userAttendActivityTable.activityId, activityId));
 
-  const currentCount = countResult[0]?.count || 0;
-  // console.log(currentCount)
+  const currentCount = Number(countResult[0]?.count) || 0;
 
   if (currentCount >= maxParticipants) {
     return { success: false, message: "人數已滿，無法再報名" };
@@ -81,7 +80,7 @@ const joinActivity = async (userId, activityId) => {
     activityId,
   });
 
-  return { success: true, message: "成功加入活動" };
+  return { success: true, message: "成功加入活動",current_participants:currentCount };
 };
 
 const cancelJoinActivity = async (userId, activityId) => {


### PR DESCRIPTION
功能調整：加上活動人數上限驗證與統計
1. 在使用者報名活動時，加入「人數已滿」的邏輯檢查，避免超額報名。

2. 在查詢活動列表時，補充回傳 max_participants 及 current_participants，讓前端可以顯示目前報名進度。

3. 使用 SQL 的 COUNT() 與 GROUP BY，確保每筆活動都有統計參加人數。