### PR TITLE
[ 新增 API：查詢使用者各活動狀態（已加入／已滿／可加入）]

### DIFF
--- a/src/controllers/activityControllers.js
+++ b/src/controllers/activityControllers.js
@@ -1,6 +1,6 @@
 const db = require("../db/index.js");
 const { activities, usersTable,userAttendActivityTable } = require("../db/schema.js");
-const { eq, and, sql, desc } = require("drizzle-orm");
+const { eq, and, sql, desc,count,inArray } = require("drizzle-orm");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const crypto = require("crypto");
 const {
@@ -301,6 +301,63 @@ const deleteJoinActivity = async (req, res) => {
   }
 };
 
+const searchActivitiesStatus = async (req, res) =>{
+  const { userId, activityIds } = req.body;
+
+  try {
+    // 查詢所有該使用者已報名的活動
+    const joinedActivities = await db
+      .select({ activityId: userAttendActivityTable.activityId })
+      .from(userAttendActivityTable)
+      .where(and(
+        eq(userAttendActivityTable.userId, userId),
+        inArray(userAttendActivityTable.activityId, activityIds)
+      ));
+
+    const joinedSet = new Set(joinedActivities.map(a => a.activityId));
+
+    // 查詢所有活動的最大人數
+    const activitiesData = await db
+      .select({
+        id: activities.id,
+        maxParticipants: activities.max_participants
+      })
+      .from(activities)
+      .where(inArray(activities.id, activityIds));
+
+    // 查詢所有活動的目前參加人數
+    const countResults = await db
+      .select({
+        activityId: userAttendActivityTable.activityId,
+        count: count().as("count")
+      })
+      .from(userAttendActivityTable)
+      .where(inArray(userAttendActivityTable.activityId, activityIds))
+      .groupBy(userAttendActivityTable.activityId);
+
+    const countMap = new Map(countResults.map(row => [row.activityId, row.count]));
+
+    // 組合每個活動的狀態
+    const statuses = activitiesData.map(activity => {
+      if (joinedSet.has(activity.id)) {
+        return { activityId: activity.id, status: 'ALREADY_JOINED' };
+      }
+
+      const currentCount = countMap.get(activity.id) || 0;
+      if (currentCount >= activity.maxParticipants) {
+        return { activityId: activity.id, status: 'FULL' };
+      }
+
+      return { activityId: activity.id, status: 'OPEN' };
+    });
+
+    return res.json({ statuses });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
 module.exports = {
   getAllActivities,
   getMyActivities,
@@ -311,4 +368,5 @@ module.exports = {
   postJoinActivity,
   deleteJoinActivity,
   getMyJoinActivity,
+  searchActivitiesStatus
 };

--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -13,6 +13,7 @@ const {
   getMyJoinActivity,
   postJoinActivity,
   deleteJoinActivity,
+  searchActivitiesStatus,
 } = require("../controllers/activityControllers.js");
 
 const authMiddleware = require("../middleware/auth.js");
@@ -141,4 +142,5 @@ router.post("/join/:id", authMiddleware, postJoinActivity);
  *           type: integer
  */
 router.delete("/join/:id", authMiddleware, deleteJoinActivity);
+router.post("/status", authMiddleware, searchActivitiesStatus)
 module.exports = router;

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -50,7 +50,7 @@ const joinActivity = async (userId, activityId) => {
     return { success: false, message: "你已經加入過此活動" };
   }
 
-  // 2. 查詢該活動最多可容納多少人
+  // 查詢該活動最多可容納多少人
   const activity = await db
     .select({ max: activities.max_participants })
     .from(activities)


### PR DESCRIPTION
1.新增 searchActivitiesStatus API，讓前端能夠一次查詢多個活動對某使用者的狀態。每個活動會回傳以下三種狀態之一：

ALREADY_JOINED：使用者已報名
FULL：活動已滿
OPEN：可報名

2.實作細節

查詢使用者已參加的活動 ID
查詢各活動最大人數
統計各活動目前報名人數
組合以上資訊產出每個活動的狀態