### PR TITLE
[ 配對池篩選邏輯 ] 增加硬條件過濾｜性向、年齡區間

### DIFF
--- a/src/controllers/editProfileController.js
+++ b/src/controllers/editProfileController.js
@@ -81,14 +81,14 @@ const createProfile = async (req, res) => {
       .values({
         userId: userId,
         name: name || "",
-        gender: gender || "U", // U 表示 unknown
+        gender: gender || -1, // -1 表示 未知未填寫
         bio: bio || "",
-        age: age || 0,
+        age: age || null,
         city: city || "",
         zodiac: zodiac || "",
         mbti: mbti || "",
         job: job || "",
-        orientation: orientation || 2, // 沒填就預設男女都可以
+        orientation: orientation || 2, // 沒填預設男女都可以
       })
       .returning();
 

--- a/src/controllers/userFilterControllers.js
+++ b/src/controllers/userFilterControllers.js
@@ -7,8 +7,8 @@ const saveUserInterests = async (req, res) => {
   const userId = req.user?.id;
   const { interestIds } = req.body;
 
-  if (!Array.isArray(interestIds)) {
-    return res.status(400).json({ message: "interestIds 必須是陣列" });
+  if (!Array.isArray(interestIds) || interestIds.length === 0) {
+    return res.status(400).json({ message: "請挑選至少一個你感興趣的選項" });
   }
 
   try {

--- a/src/controllers/userProfileControllers.js
+++ b/src/controllers/userProfileControllers.js
@@ -1,14 +1,14 @@
 // 引入service資料夾要查詢使用者的 資料庫函式
 const db = require("../db/index.js");
 
-const { profileTable, photosTable } = require("../db/schema");
+const { profileTable } = require("../db/schema");
 const { eq, not } = require("drizzle-orm"); // 引入 neq 用於不等於判斷
 const { getProfileByIdFromDB } = require("../services/userProfile");
 const { findSpecifiedPhotos } = require("../services/userPhoto");
 const { getRecommendedUsers } = require("../services/recommendationService");
 
 // GET 加入篩選邏輯的配對對象
-// 拿到除了自己之外的所有使用者資料
+// 「推薦排序 + 個人資料 + 照片」
 const getSortedProfiles = async (req, res) => {
   try {
     const userId = req.user?.id;
@@ -90,7 +90,12 @@ const getSortedProfiles = async (req, res) => {
       photos: photoMap[user.userId] || [],
     }));
 
-    usersWithPhotos.forEach((user) => {
+    const filteredWithPhotos = usersWithPhotos.filter(
+      (user) => user.photos.length > 0
+    );
+
+    // 印出「有照片的使用者」的照片資訊 debug 用
+    filteredWithPhotos.forEach((user) => {
       console.log(` 使用者 ${user.userId} 的照片：`);
       user.photos.forEach((photo, index) => {
         console.log(`   第 ${index + 1} 張:`, photo);
@@ -99,7 +104,7 @@ const getSortedProfiles = async (req, res) => {
 
     res.status(200).json({
       message: "取得配對對象成功",
-      users: usersWithPhotos,
+      users: filteredWithPhotos,
     });
   } catch (error) {
     console.error("getAllProfiles failed:", error.message);

--- a/src/services/recommendationService.js
+++ b/src/services/recommendationService.js
@@ -106,6 +106,7 @@ async function getRecommendedUsers(userId) {
       return {
         ...targetPref,
         score,
+        photos: targetPhotos,
       };
     })
   );

--- a/src/services/recommendationService.js
+++ b/src/services/recommendationService.js
@@ -5,6 +5,7 @@ const {
   profileTable,
 } = require("../db/schema.js");
 const { eq, ne } = require("drizzle-orm");
+const { findSpecifiedPhotos } = require("./userPhoto.js");
 
 async function getUserInterests(userId) {
   const rows = await db
@@ -15,64 +16,109 @@ async function getUserInterests(userId) {
   return rows.map((row) => row.interestId);
 }
 
-async function getRecommendedUsers(userId) {
+// 性別欄位值轉換 0:female 1:male
+const genderToNum = (gender) => {
+  if (gender === "female") return 0;
+  if (gender === "male") return 1;
+  else return -1; // 表示 未知未填寫
+};
 
-  const currentUserResult = await db
+// 性向比對邏輯: 0同性 1異性 2都可
+const matchOrientation = (orientation, userGender, targetGender) => {
+  if (orientation === 2) return true;
+  if (orientation === 0) return userGender === targetGender;
+  if (orientation === 1) return userGender !== targetGender;
+  return false;
+};
+
+async function getRecommendedUsers(userId) {
+  const currentUserPrefResult = await db
     .select()
     .from(userPreferencesTable)
     .where(eq(userPreferencesTable.userId, userId));
 
-  const currentUser = currentUserResult[0];
-  if (!currentUser) {
-    throw new Error(`無法找到使用者 ${userId}`); 
+  const userPref = currentUserPrefResult[0];
+  if (!userPref) {
+    throw new Error(`無法找到使用者 ${userId}`);
   }
 
-  const otherUsers = await db
+  const targetPrefResult = await db
     .select()
     .from(userPreferencesTable)
     .where(ne(userPreferencesTable.userId, userId));
 
   const allProfiles = await db.select().from(profileTable);
-  const profileAgeMap = new Map();
-  allProfiles.forEach(profile => {
-    profileAgeMap.set(profile.userId, profile.age);
+  const profileMap = new Map();
+  allProfiles.forEach((profile) => {
+    profileMap.set(profile.userId, profile);
   });
 
-  const currentUserInterests = await getUserInterests(userId);
+  const userProfile = profileMap.get(userId);
+  const userGender = genderToNum(userProfile?.gender);
+  const userOrientation = userProfile?.orientation;
+  const userInterests = await getUserInterests(userId);
 
+  // 開始比對推薦對象
   const recommendations = await Promise.all(
-    otherUsers.map(async (other) => {
+    targetPrefResult.map(async (targetPref) => {
+      const targetUserId = targetPref.userId;
+      const targetProfile = profileMap.get(targetUserId);
+      if (!targetProfile) return null;
+
+      const targetGender = genderToNum(targetProfile.gender);
+      const targetOrientation = targetProfile.orientation;
+      const targetAge = targetProfile.age;
+
+      // 雙向性向條件檢查 彼此接受
+      const isMatch =
+        matchOrientation(userOrientation, userGender, targetGender) &&
+        matchOrientation(targetOrientation, targetGender, userGender);
+
+      if (!isMatch) return null;
+
+      // 補檢查照片數量 過濾條件
+      const targetPhotos = await findSpecifiedPhotos(targetUserId, {
+        sequenceRange: [1, 6],
+      });
+
+      if (!targetPhotos || targetPhotos.length < 1) {
+        return null;
+      }
+
       let score = 0;
 
-      const otherAge = profileAgeMap.get(other.userId);
-      if (otherAge >= currentUser.ageMin && otherAge <= currentUser.ageMax) {
+      if (targetAge >= userPref.ageMin && targetAge <= userPref.ageMax) {
         score++;
       }
 
-      if (other.musicMatch === currentUser.musicMatch) score++;
-      if (other.introvertOrExtrovert === currentUser.introvertOrExtrovert)
+      if (targetPref.musicMatch === userPref.musicMatch) score++;
+      if (targetPref.introvertOrExtrovert === userPref.introvertOrExtrovert)
         score++;
-      if (other.pet === currentUser.pet) score++;
-      if (other.wakeUpTime === currentUser.wakeUpTime) score++;
+      if (targetPref.pet === userPref.pet) score++;
+      if (targetPref.wakeUpTime === userPref.wakeUpTime) score++;
 
-      const otherUserInterests = await getUserInterests(other.userId); 
-      const sharedInterests = otherUserInterests.filter((i) =>
-        currentUserInterests.includes(i)
+      const targetInterests = await getUserInterests(targetUserId);
+      const sharedInterests = targetInterests.filter((i) =>
+        userInterests.includes(i)
       );
       score += sharedInterests.length;
 
       return {
-        ...other,
+        ...targetPref,
         score,
       };
     })
   );
 
-  const sorted = recommendations.sort((a, b) => b.score - a.score);
+  const sorted = recommendations
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score);
 
   const finalRecommendations = sorted
-    .slice(0, 20)
-    .map(({ score, ...rest }) => rest);
+    .slice(0, 30) // 用前端鎖人數
+    .map(({ score, ...rest }) => rest); // 拿掉 score 再傳給前端
+
+  console.log("這是sorted出來的值:", sorted);
 
   return finalRecommendations;
 }


### PR DESCRIPTION
#93 

找出目前使用者偏好 `userPref ` 與 `userProfile`
從資料庫抓出所有其他人的偏好 `targetPref` 與 `targetProfile`

**篩選比對**
照片條件：先排除掉 沒上傳照片的對象 (最少1張)
- 雙向性向條件
- 有無生活照
- 年齡、音樂、個性、寵物、作息
- 興趣重疊數
- 計分後排序，回傳最高分前 **30 人** 

備註：目前先暫設篩選邏輯會回傳30個人選，接著前端再切取想要的數量
因為多了硬條件過濾之後沒這麼好篩，此版先以可測試、demo的數量為主