### PR TITLE
[ 優化篩選邏輯 ] 放寬條件機制、驗證生活照至少1張

### DIFF
--- a/src/controllers/recommendControllers.js
+++ b/src/controllers/recommendControllers.js
@@ -6,8 +6,8 @@ async function getRecommendations(req, res) {
     return res.status(401).json({ message: "未授權操作，請先登入" });
   }
   try {
-    const matches = await getRecommendedUsers(userId);
-    res.status(200).json(matches);
+    const { data, relaxed } = await getRecommendedUsers(userId);
+    res.status(200).json({ relaxed, data });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "內部伺服器錯誤" });

--- a/src/controllers/recommendControllers.js
+++ b/src/controllers/recommendControllers.js
@@ -1,17 +1,15 @@
 const { getRecommendedUsers } = require("../services/recommendationService.js");
 
 async function getRecommendations(req, res) {
-  const userId = Number(req.params.userId);
-
+  const userId = req.user?.id;
   if (!userId) {
-    return res.status(404).json({ error: "使用者資料不存在" });
+    return res.status(401).json({ message: "未授權操作，請先登入" });
   }
-
   try {
     const matches = await getRecommendedUsers(userId);
     res.status(200).json(matches);
   } catch (error) {
-    console.error(error)
+    console.error(error);
     res.status(500).json({ error: "內部伺服器錯誤" });
   }
 }

--- a/src/routes/recommendationRoutes.js
+++ b/src/routes/recommendationRoutes.js
@@ -1,21 +1,46 @@
 const express = require("express");
 const { getRecommendations } = require("../controllers/recommendControllers");
+const authMiddleware = require("../middleware/auth.js");
 
 const router = express.Router();
 
 /**
  * @swagger
- * /recommendations/{userId}:
+ * /recommendations/me:
  *   get:
- *     summary: 取得配對推薦
+ *     summary: 取得目前登入者的配對推薦
  *     tags: [Recommendation]
- *     parameters:
- *       - in: path
- *         name: userId
- *         required: true
- *         schema:
- *           type: integer
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 成功取得推薦對象
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 relaxed:
+ *                   type: boolean
+ *                   description: 是否放寬條件
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       userId:
+ *                         type: integer
+ *                       name:
+ *                         type: string
+ *                       age:
+ *                         type: integer
+ *                       gender:
+ *                         type: string
+ *       401:
+ *         description: 未授權，請先登入
+ *       500:
+ *         description: 伺服器錯誤
  */
-router.get("/:userId", getRecommendations);
+router.get("/me", authMiddleware, getRecommendations);
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -74,7 +74,6 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/auth", authRoutes);
-app.use("/recommendations", recommendationRoutes);
 app.use("/order", orderRoutes);
 app.use("/products", productRoutes);
 app.use("/activities", activityRoutes);
@@ -94,7 +93,7 @@ app.use("/api/subPlans", subPlansRoutes);
 app.use("/paypal", paypalRoutes);
 app.use("/matches", matchesRoutes);
 app.use("/user-filter", userFilterRoutes);
-
+app.use("/recommend", recommendationRoutes);
 /**
  * @swagger
  * /api/me:
@@ -165,7 +164,7 @@ app.get("/api/me", authMiddleware, async (req, res) => {
           )
           .where(eq(usersTable.id, req.user.id));
 
-          console.log("重新更新過的使用者資料:",updatedUser);
+        console.log("重新更新過的使用者資料:", updatedUser);
         return res.json({
           user: {
             username: user.username,
@@ -175,7 +174,6 @@ app.get("/api/me", authMiddleware, async (req, res) => {
           },
         });
       }
-
     }
     // 正常回傳 user（沒過期）
     res.json({

--- a/src/services/recommendationService.js
+++ b/src/services/recommendationService.js
@@ -59,8 +59,10 @@ async function getRecommendedUsers(userId) {
   const userInterests = await getUserInterests(userId);
 
   const filterAndScore = async (relaxAge = false) => {
-    const ageMin = relaxAge ? userPref.ageMin - 8 : userPref.ageMin;
-    const ageMax = relaxAge ? userPref.ageMax + 8 : userPref.ageMax;
+    const ageMin = relaxAge ? userPref.ageMin - 5 : userPref.ageMin;
+    const ageMax = relaxAge ? userPref.ageMax + 5 : userPref.ageMax;
+
+    console.log(`🎯 比對條件：ageMin=${ageMin}, ageMax=${ageMax}`);
 
     // 開始比對推薦對象
     const recommendations = await Promise.all(
@@ -81,8 +83,10 @@ async function getRecommendedUsers(userId) {
         if (!isMatch) return null;
 
         // 年齡不符跳過
-        if (targetAge < ageMin || targetAge > ageMax) return null;
-
+        if (targetAge < ageMin || targetAge > ageMax) {
+          console.log(`🚫 排除年齡不符：${targetProfile.name} (${targetAge})`);
+          return null;
+        }
         // 補檢查照片數量 過濾條件
         const targetPhotos = await findSpecifiedPhotos(targetUserId, {
           sequenceRange: [1, 6],
@@ -106,9 +110,17 @@ async function getRecommendedUsers(userId) {
         score += sharedInterests.length;
 
         return {
-          ...targetPref,
-          score,
+          userId: targetUserId,
           photos: targetPhotos,
+          score,
+          name: targetProfile?.name || "",
+          age: targetProfile?.age || null,
+          city: targetProfile?.city || "",
+          mbti: targetProfile?.mbti || "",
+          zodiac: targetProfile?.zodiac || "",
+          job: targetProfile?.job || "",
+          bio: targetProfile?.bio || "",
+          ...targetPref,
         };
       })
     );
@@ -118,7 +130,7 @@ async function getRecommendedUsers(userId) {
       .sort((a, b) => b.score - a.score);
 
     const finalRecommendations = sorted
-      .slice(0, 30) // 用前端鎖人數
+      .slice(0, 5) // 改這邊
       .map(({ score, ...rest }) => rest); // 拿掉 score 再傳給前端
 
     console.log("這是sorted出來的值:", sorted);
@@ -126,25 +138,36 @@ async function getRecommendedUsers(userId) {
     return finalRecommendations;
   };
   // 嘗試先用 原本年齡區間
-  let sorted = await filterAndScore(false);
+  let hardSortedResult = await filterAndScore(false);
   let relaxed = false;
 
+  const minResult = 20;
+
   // 如果找不到 放寬條件
-  if (sorted.length < 50) {
-    const relaxedSorted = await filterAndScore(true);
-    if (relaxedSorted.length > sorted.length) {
-      sorted = await relaxedSorted;
+  if (hardSortedResult.length < minResult) {
+    const relaxedSortedResult = await filterAndScore(true);
+    if (relaxedSortedResult.length > hardSortedResult.length) {
+      hardSortedResult = relaxedSortedResult;
       relaxed = true;
     }
   }
+
+  const sorted = hardSortedResult
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score);
+
   const finalRecommendations = sorted
-    .slice(0, 30)
+    .slice(0, 10)
     .map(({ score, ...rest }) => rest);
 
-  return {
-    users: finalRecommendations,
+  console.log(" 篩選後的對象：", finalRecommendations.length, "人");
+  console.log(" 回傳結果：", {
     relaxed,
+    finalRecommendations,
+  });
+  return {
+    relaxed,
+    data: finalRecommendations,
   };
 }
-
 module.exports = { getRecommendedUsers };

--- a/src/services/recommendationService.js
+++ b/src/services/recommendationService.js
@@ -58,70 +58,93 @@ async function getRecommendedUsers(userId) {
   const userOrientation = userProfile?.orientation;
   const userInterests = await getUserInterests(userId);
 
-  // 開始比對推薦對象
-  const recommendations = await Promise.all(
-    targetPrefResult.map(async (targetPref) => {
-      const targetUserId = targetPref.userId;
-      const targetProfile = profileMap.get(targetUserId);
-      if (!targetProfile) return null;
+  const filterAndScore = async (relaxAge = false) => {
+    const ageMin = relaxAge ? userPref.ageMin - 8 : userPref.ageMin;
+    const ageMax = relaxAge ? userPref.ageMax + 8 : userPref.ageMax;
 
-      const targetGender = genderToNum(targetProfile.gender);
-      const targetOrientation = targetProfile.orientation;
-      const targetAge = targetProfile.age;
+    // 開始比對推薦對象
+    const recommendations = await Promise.all(
+      targetPrefResult.map(async (targetPref) => {
+        const targetUserId = targetPref.userId;
+        const targetProfile = profileMap.get(targetUserId);
+        if (!targetProfile) return null;
 
-      // 雙向性向條件檢查 彼此接受
-      const isMatch =
-        matchOrientation(userOrientation, userGender, targetGender) &&
-        matchOrientation(targetOrientation, targetGender, userGender);
+        const targetGender = genderToNum(targetProfile.gender);
+        const targetOrientation = targetProfile.orientation;
+        const targetAge = targetProfile.age;
 
-      if (!isMatch) return null;
+        // 雙向性向條件檢查 彼此接受
+        const isMatch =
+          matchOrientation(userOrientation, userGender, targetGender) &&
+          matchOrientation(targetOrientation, targetGender, userGender);
 
-      // 補檢查照片數量 過濾條件
-      const targetPhotos = await findSpecifiedPhotos(targetUserId, {
-        sequenceRange: [1, 6],
-      });
+        if (!isMatch) return null;
 
-      if (!targetPhotos || targetPhotos.length < 1) {
-        return null;
-      }
+        // 年齡不符跳過
+        if (targetAge < ageMin || targetAge > ageMax) return null;
 
-      let score = 0;
+        // 補檢查照片數量 過濾條件
+        const targetPhotos = await findSpecifiedPhotos(targetUserId, {
+          sequenceRange: [1, 6],
+        });
+        if (!targetPhotos || targetPhotos.length < 1) {
+          return null;
+        }
 
-      if (targetAge >= userPref.ageMin && targetAge <= userPref.ageMax) {
-        score++;
-      }
+        let score = 0;
+        score++; // 年齡已通過篩選
+        if (targetPref.musicMatch === userPref.musicMatch) score++;
+        if (targetPref.introvertOrExtrovert === userPref.introvertOrExtrovert)
+          score++;
+        if (targetPref.pet === userPref.pet) score++;
+        if (targetPref.wakeUpTime === userPref.wakeUpTime) score++;
 
-      if (targetPref.musicMatch === userPref.musicMatch) score++;
-      if (targetPref.introvertOrExtrovert === userPref.introvertOrExtrovert)
-        score++;
-      if (targetPref.pet === userPref.pet) score++;
-      if (targetPref.wakeUpTime === userPref.wakeUpTime) score++;
+        const targetInterests = await getUserInterests(targetUserId);
+        const sharedInterests = targetInterests.filter((i) =>
+          userInterests.includes(i)
+        );
+        score += sharedInterests.length;
 
-      const targetInterests = await getUserInterests(targetUserId);
-      const sharedInterests = targetInterests.filter((i) =>
-        userInterests.includes(i)
-      );
-      score += sharedInterests.length;
+        return {
+          ...targetPref,
+          score,
+          photos: targetPhotos,
+        };
+      })
+    );
 
-      return {
-        ...targetPref,
-        score,
-        photos: targetPhotos,
-      };
-    })
-  );
+    const sorted = recommendations
+      .filter(Boolean)
+      .sort((a, b) => b.score - a.score);
 
-  const sorted = recommendations
-    .filter(Boolean)
-    .sort((a, b) => b.score - a.score);
+    const finalRecommendations = sorted
+      .slice(0, 30) // 用前端鎖人數
+      .map(({ score, ...rest }) => rest); // 拿掉 score 再傳給前端
 
+    console.log("這是sorted出來的值:", sorted);
+
+    return finalRecommendations;
+  };
+  // 嘗試先用 原本年齡區間
+  let sorted = await filterAndScore(false);
+  let relaxed = false;
+
+  // 如果找不到 放寬條件
+  if (sorted.length < 50) {
+    const relaxedSorted = await filterAndScore(true);
+    if (relaxedSorted.length > sorted.length) {
+      sorted = await relaxedSorted;
+      relaxed = true;
+    }
+  }
   const finalRecommendations = sorted
-    .slice(0, 30) // 用前端鎖人數
-    .map(({ score, ...rest }) => rest); // 拿掉 score 再傳給前端
+    .slice(0, 30)
+    .map(({ score, ...rest }) => rest);
 
-  console.log("這是sorted出來的值:", sorted);
-
-  return finalRecommendations;
+  return {
+    users: finalRecommendations,
+    relaxed,
+  };
 }
 
 module.exports = { getRecommendedUsers };


### PR DESCRIPTION
 closed #97 

_DEMO 免費：10 / 付費(20?)_ 


- [x] 路由修改：用 JWT 驗證，從 `req.user` 取得 userId，移除 userId 參數

- 支援條件放寬的切換邏輯 `relaxAge 參數`
- 回傳包含 relaxed: true/false 狀態，給前端判斷是否顯示「**條件已放寬**」訊息
  - 最少能撈出 20位 ⇨ 才不用放寬年齡條件
  - 放寬的條件將年齡改為`ageMin - 5、ageMax + 5` 擴充人選
- 判斷「照片數量 >= 1 張」作為進入配對池的資格門檻

