### PR TITLE
修復前端活動頁面誤判活動不存在的問題

### DIFF
--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -65,7 +65,7 @@ router.get("/me", authMiddleware, getMyJoinActivity);
  *         schema:
  *           type: integer
  */
-router.get("/:id", authMiddleware, getActivityById);
+router.get("/:id", getActivityById);
 /**
  * @swagger
  * /activities:


### PR DESCRIPTION
原本前端如果未登入會因為沒拿到活動ID導致誤判成活動未登入
故後端這邊 `getActivityById` 一併做修改