### PR TITLE
[ BugFix: 修正按鈕觸發回應 ] 區分409 、第一次發送

### DIFF
--- a/src/controllers/likesControllers.js
+++ b/src/controllers/likesControllers.js
@@ -33,21 +33,14 @@ const createLike = async (req, res) => {
       .select()
       .from(likesTable)
       .where(
-        and(
-          eq(likesTable.userId, userId),
-          eq(likesTable.targetId, targetId),
-          eq(likesTable.status, 1) // 只擋送過 like，讓 dislike 通過
-        )
+        and(eq(likesTable.userId, userId), eq(likesTable.targetId, targetId))
       );
 
-    if (
-      (status === 1 && myLikesRecord.length > 0) ||
-      (status === 2 && mySuperLikesRecord.length > 0)
-    ) {
+    if (myLikesRecord.length > 0 || mySuperLikesRecord.length > 0) {
       return res.status(409).json({
         success: false,
         matched: false,
-        message: "你已經送出反應，請勿重複操作",
+        message: "已回應過，等待對方回應中...",
       });
     }
 

--- a/src/controllers/likesControllers.js
+++ b/src/controllers/likesControllers.js
@@ -33,14 +33,21 @@ const createLike = async (req, res) => {
       .select()
       .from(likesTable)
       .where(
-        and(eq(likesTable.userId, userId), eq(likesTable.targetId, targetId))
+        and(
+          eq(likesTable.userId, userId),
+          eq(likesTable.targetId, targetId),
+          eq(likesTable.status, 1) // 只擋送過 like，讓 dislike 通過
+        )
       );
 
-    if (mySuperLikesRecord.length > 0 || myLikesRecord.length > 0) {
+    if (
+      (status === 1 && myLikesRecord.length > 0) ||
+      (status === 2 && mySuperLikesRecord.length > 0)
+    ) {
       return res.status(409).json({
         success: false,
         matched: false,
-        message: "已發送過，等待對方回應中...",
+        message: "你已經送出反應，請勿重複操作",
       });
     }
 
@@ -64,7 +71,7 @@ const createLike = async (req, res) => {
         )
       );
 
-    if (targetLikesRecord.length > 0) {
+    if (targetLikesRecord.length > 0 && status === 1) {
       await db
         .insert(matchesTable)
         .values({
@@ -119,13 +126,13 @@ const createLike = async (req, res) => {
         myProfile,
         message: "雙方配對成功！",
       });
-    } else {
-      return res.json({
-        success: true,
-        matched: false,
-        message: "已發送過，等待對方回應中...",
-      });
     }
+
+    return res.status(200).json({
+      success: true,
+      matched: false,
+      message: "送出成功，等待對方回應中...",
+    });
   } catch (error) {
     console.error("Create like failed:", error.message);
     res.status(500).json({ message: "伺服器錯誤，請稍後再試" });


### PR DESCRIPTION
<img width="551" alt="image" src="https://github.com/user-attachments/assets/c3baa79c-a85e-4969-9fa4-1c28ab86bc5b" />
<img width="557" alt="image" src="https://github.com/user-attachments/assets/5b52a280-2747-4b5e-a594-de0610d45675" />


問題：
無條件擋住任何針對同一對象（targetId）的紀錄」，第一次送出也被當作重複行為
不論是按  (status=1) 或 dislike (status=0)，都無條件被擋住，都被當成「重複發送」而回傳 409

修正邏輯：
- 不需要判斷status 只要管有沒有喜歡不喜歡的紀錄
- 曾經按過 like 再按一次 like ⇨ 回傳錯誤（409）